### PR TITLE
Add unit tests for EventStoreStatistics, KeyId, KeyMap, and PaddedLoc…

### DIFF
--- a/tests/LockFree.EventStore.Tests/EventStoreStatisticsTests.cs
+++ b/tests/LockFree.EventStore.Tests/EventStoreStatisticsTests.cs
@@ -1,0 +1,76 @@
+using System;
+using LockFree.EventStore;
+using Xunit;
+
+namespace LockFree.EventStore.Tests;
+
+public class EventStoreStatisticsTests
+{
+    [Fact]
+    public void RecordAppend_UpdatesTotals_And_LastAppendTime()
+    {
+        var stats = new EventStoreStatistics();
+        Assert.Equal(0, stats.TotalAppended);
+        Assert.Equal(0, stats.TotalDiscarded);
+        Assert.Equal(default, stats.LastAppendTime);
+
+        stats.RecordAppend();
+
+        Assert.Equal(1, stats.TotalAppended);
+        Assert.Equal(0, stats.TotalDiscarded);
+        Assert.NotEqual(default, stats.LastAppendTime);
+
+        // Immediately after append, elapsed < 1s, should return total appended
+        Assert.True(stats.AppendsPerSecond >= 1);
+    }
+
+    [Fact]
+    public void IncrementTotalAdded_Overloads_Work_And_AppendsPerSecond_Branches_Covered()
+    {
+        var stats = new EventStoreStatistics();
+
+        // With default LastAppendTime, elapsed >= 1s path is taken and returns 0
+        Assert.Equal(0, stats.AppendsPerSecond);
+
+        stats.IncrementTotalAdded();
+        Assert.Equal(1, stats.TotalAppended);
+        var t1 = stats.LastAppendTime;
+        Assert.NotEqual(default, t1);
+
+        stats.IncrementTotalAdded(4);
+        Assert.Equal(5, stats.TotalAppended);
+        var t2 = stats.LastAppendTime;
+        Assert.True(t2 >= t1);
+
+        // Immediately after increment, elapsed < 1s path is taken, returns total appended
+        Assert.True(stats.AppendsPerSecond >= 5);
+    }
+
+    [Fact]
+    public void RecordDiscard_And_IncrementOverwritten_Accumulate_Discarded()
+    {
+        var stats = new EventStoreStatistics();
+        stats.RecordDiscard();
+        stats.IncrementOverwritten();
+        Assert.Equal(2, stats.TotalDiscarded);
+    }
+
+    [Fact]
+    public void Reset_Clears_All_Counters_And_Time()
+    {
+        var stats = new EventStoreStatistics();
+        stats.RecordAppend();
+        stats.RecordDiscard();
+        Assert.True(stats.TotalAppended > 0);
+        Assert.True(stats.TotalDiscarded > 0);
+        Assert.NotEqual(default, stats.LastAppendTime);
+
+        stats.Reset();
+
+        Assert.Equal(0, stats.TotalAppended);
+        Assert.Equal(0, stats.TotalDiscarded);
+        Assert.Equal(default, stats.LastAppendTime);
+        // With default time, APS uses long-elapsed branch returning 0
+        Assert.Equal(0, stats.AppendsPerSecond);
+    }
+}

--- a/tests/LockFree.EventStore.Tests/KeyIdAndKeyMapTests.cs
+++ b/tests/LockFree.EventStore.Tests/KeyIdAndKeyMapTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using LockFree.EventStore;
+using Xunit;
+
+namespace LockFree.EventStore.Tests;
+
+public class KeyIdAndKeyMapTests
+{
+    [Fact]
+    public void KeyId_Behavior_Equals_HashCode_ToString_Implicit()
+    {
+        var k1 = new KeyId(42);
+        var k2 = new KeyId(42);
+        var k3 = new KeyId(7);
+
+        Assert.Equal(k1, k2);
+        Assert.NotEqual(k1, k3);
+        Assert.Equal(42, k1.Value);
+        Assert.Equal(42, k1.GetHashCode());
+        Assert.Equal("KeyId(42)", k1.ToString());
+
+        int iv = k1; // implicit
+        Assert.Equal(42, iv);
+    }
+
+    [Fact]
+    public void KeyMap_GetOrAdd_And_TryGet_BothWays()
+    {
+        var map = new KeyMap();
+        var idA1 = map.GetOrAdd("A");
+        var idA2 = map.GetOrAdd("A");
+        var idB = map.GetOrAdd("B");
+
+        Assert.Equal(idA1, idA2);
+        Assert.NotEqual(idA1, idB);
+        Assert.Equal(2, map.Count);
+
+        Assert.True(map.TryGet("A", out var idA));
+        Assert.Equal(idA1, idA);
+        Assert.False(map.TryGet("X", out _));
+
+        Assert.True(map.TryGet(idB, out var keyB));
+        Assert.Equal("B", keyB);
+        Assert.False(map.TryGet(new KeyId(999), out _));
+
+        var all = map.GetAllMappings();
+        Assert.True(all.ContainsKey("A"));
+        Assert.True(all.ContainsKey("B"));
+        Assert.Equal(idA1, all["A"]);
+        Assert.Equal(map.Count, all.Count);
+    }
+
+    [Fact]
+    public void KeyMap_Clear_Resets_State_And_Sequence()
+    {
+        var map = new KeyMap();
+        var id1 = map.GetOrAdd("one");
+        var id2 = map.GetOrAdd("two");
+        Assert.Equal(2, map.Count);
+
+        map.Clear();
+        Assert.Equal(0, map.Count);
+        Assert.False(map.TryGet("one", out _));
+        Assert.False(map.TryGet(id1, out _));
+
+        var id1Again = map.GetOrAdd("one");
+        Assert.Equal(1, id1Again.Value); // sequence restarted
+    }
+}

--- a/tests/LockFree.EventStore.Tests/LockFreeRingBufferTests.cs
+++ b/tests/LockFree.EventStore.Tests/LockFreeRingBufferTests.cs
@@ -137,4 +137,140 @@ public class LockFreeRingBufferTests
 
         Assert.True(finalState > 10);
     }
+
+    [Fact]
+    public void Constructor_Invalid_Capacity_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LockFreeRingBuffer<int>(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new LockFreeRingBuffer<int>(-5));
+    }
+
+    [Fact]
+    public void Snapshot_On_Empty_Returns_Zero_And_EnumerateSnapshot_Is_Empty()
+    {
+        var buf = new LockFreeRingBuffer<int>(4);
+        var tmp = new int[4];
+        Assert.Equal(0, buf.Snapshot(tmp));
+        Assert.Empty(buf.EnumerateSnapshot());
+    }
+
+    [Fact]
+    public void Clear_Resets_Buffer_And_View_Is_Empty()
+    {
+        var buf = new LockFreeRingBuffer<int>(4);
+        foreach (var i in Enumerable.Range(1, 4)) buf.TryEnqueue(i);
+        Assert.True(buf.IsFull);
+        buf.Clear();
+        Assert.True(buf.IsEmpty);
+        var arr = new int[4];
+        Assert.Equal(0, buf.Snapshot(arr));
+        var view = buf.CreateView();
+        Assert.True(view.IsEmpty);
+        Assert.Equal(0, view.Count);
+    }
+
+    [Fact]
+    public void TryEnqueue_ReadOnlySpan_Batch_Works()
+    {
+        var buf = new LockFreeRingBuffer<int>(6);
+        var batch = new[] { 1, 2, 3, 4 };
+        var written = buf.TryEnqueue((ReadOnlySpan<int>)batch);
+        Assert.Equal(batch.Length, written);
+        var dst = new int[6];
+        var n = buf.Snapshot(dst);
+        Assert.Equal(4, n);
+        Assert.True(dst.Take(4).SequenceEqual(batch));
+    }
+
+    [Fact]
+    public void CreateView_With_TimestampSelector_Sets_Ticks_NoWrap_And_Wrap()
+    {
+        var sel = new EventTimestampSelector();
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+
+        // No wrap
+        var buf1 = new LockFreeRingBuffer<Event>(8);
+        for (int i = 0; i < 3; i++) buf1.TryEnqueue(new Event(new KeyId(1), i, t0 + i));
+        var v1 = buf1.CreateView(sel);
+        Assert.Equal(t0, v1.FromTicks);
+        Assert.Equal(t0 + 2, v1.ToTicks);
+        Assert.False(v1.HasWrapAround);
+
+        // Wrap case
+        var buf2 = new LockFreeRingBuffer<Event>(5);
+        for (int i = 0; i < 7; i++) buf2.TryEnqueue(new Event(new KeyId(1), i, t0 + i));
+        var v2 = buf2.CreateView(sel);
+        Assert.Equal(t0 + 2, v2.FromTicks);
+        Assert.Equal(t0 + 6, v2.ToTicks);
+        Assert.True(v2.HasWrapAround);
+    }
+
+    [Fact]
+    public void CreateViewFiltered_Empty_When_No_Items_In_Window()
+    {
+        var sel = new EventTimestampSelector();
+        var buf = new LockFreeRingBuffer<Event>(6);
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        for (int i = 0; i < 3; i++) buf.TryEnqueue(new Event(new KeyId(1), i, t0 + i));
+        var view = buf.CreateViewFiltered(t0 + 100, t0 + 200, sel);
+        Assert.True(view.IsEmpty);
+        Assert.Equal(0, view.Count);
+    }
+
+    [Fact]
+    public void CreateViewFiltered_WrapAround_Window()
+    {
+        var sel = new EventTimestampSelector();
+        var buf = new LockFreeRingBuffer<Event>(5);
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        for (int i = 0; i < 7; i++) buf.TryEnqueue(new Event(new KeyId(1), i, t0 + i));
+        // Current logical ticks present: t0+2 .. t0+6; choose [t0+3, t0+5] to force wrap in segments
+        var view = buf.CreateViewFiltered(t0 + 3, t0 + 5, sel);
+        Assert.Equal(3, view.Count);
+        Assert.True(view.HasWrapAround);
+        var vals = new List<double>();
+        foreach (var e in view) vals.Add(e.Value);
+        Assert.Equal(new[] { 3d, 4d, 5d }, vals.ToArray());
+    }
+
+    [Fact]
+    public void EnumerateWindow_And_AdvanceWindowTo_Work()
+    {
+        var sel = new EventTimestampSelector();
+        var buf = new LockFreeRingBuffer<Event>(8);
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        for (int i = 0; i < 6; i++) buf.TryEnqueue(new Event(new KeyId(1), i, t0 + i));
+
+        // Enumerate full window
+        var collected = new List<(double v, long t)>();
+        buf.EnumerateWindow(t0, t0 + 10, sel, ref collected, (ref List<(double v, long t)> state, Event item, long ticks) =>
+        {
+            state.Add((item.Value, ticks));
+        });
+        Assert.Equal(6, collected.Count);
+        Assert.Equal(t0, collected.First().t);
+        Assert.Equal(t0 + 5, collected.Last().t);
+
+        // Advance window to t0+3 (remove first three)
+        var removed = new List<(double v, long t)>();
+        var windowHead = 0;
+        buf.AdvanceWindowTo(t0 + 3, sel, ref removed, (ref List<(double v, long t)> state, Event item, long ticks) =>
+        {
+            state.Add((item.Value, ticks));
+        }, ref windowHead);
+        Assert.Equal(3, windowHead);
+        Assert.Equal(new long[] { t0, t0 + 1, t0 + 2 }, removed.Select(x => x.t).ToArray());
+    }
+
+    [Fact]
+    public void Snapshot_Partial_Copy_When_Destination_Smaller()
+    {
+        var buf = new LockFreeRingBuffer<int>(6);
+        foreach (var i in Enumerable.Range(1, 5)) buf.TryEnqueue(i);
+        var dst = new int[3];
+        var n = buf.Snapshot(dst);
+        Assert.Equal(3, n);
+        // Should copy the first 3 from the current head
+        Assert.Equal(new[] { 1, 2, 3 }, dst);
+    }
 }

--- a/tests/LockFree.EventStore.Tests/OptimizedPartitionTests.cs
+++ b/tests/LockFree.EventStore.Tests/OptimizedPartitionTests.cs
@@ -130,4 +130,192 @@ public class OptimizedPartitionTests
         p.Clear();
         Assert.True(p.IsEmpty);
     }
+
+    [Fact]
+    public void SoA_Only_APIs_Throw_On_AoS_Layout()
+    {
+        var p = new OptimizedPartition(4, StorageLayout.AoS);
+        Assert.Throws<InvalidOperationException>(() => p.GetKeysSpan());
+        Assert.Throws<InvalidOperationException>(() => p.GetValuesSpan());
+        Assert.Throws<InvalidOperationException>(() => p.GetTimestampsSpan());
+        Assert.Throws<InvalidOperationException>(() => p.GetKeysZeroAlloc(_ => { }));
+        Assert.Throws<InvalidOperationException>(() => p.GetValuesZeroAlloc(_ => { }));
+        Assert.Throws<InvalidOperationException>(() => p.GetTimestampsZeroAlloc(_ => { }));
+    }
+
+    [Fact]
+    public void ZeroAlloc_Getters_Do_Not_Invoke_On_Empty_SoA_And_Views_Are_Empty()
+    {
+        var pSoa = new OptimizedPartition(8, StorageLayout.SoA);
+        int k = 0, v = 0, t = 0;
+        pSoa.GetKeysZeroAlloc(_ => k++);
+        pSoa.GetValuesZeroAlloc(_ => v++);
+        pSoa.GetTimestampsZeroAlloc(_ => t++);
+        Assert.Equal(0, k);
+        Assert.Equal(0, v);
+        Assert.Equal(0, t);
+
+        // Empty views (AoS and SoA)
+        var pAos = new OptimizedPartition(4, StorageLayout.AoS);
+        var viewAos = pAos.GetView();
+        Assert.True(viewAos.IsEmpty);
+        Assert.Equal(0, viewAos.FromTicks);
+        Assert.Equal(0, viewAos.ToTicks);
+
+        pAos.GetViewZeroAlloc(view =>
+        {
+            Assert.True(view.IsEmpty);
+            Assert.Equal(0, view.FromTicks);
+            Assert.Equal(0, view.ToTicks);
+        });
+
+        var viewSoa = pSoa.GetView();
+        Assert.True(viewSoa.IsEmpty);
+        Assert.Equal(0, viewSoa.FromTicks);
+        Assert.Equal(0, viewSoa.ToTicks);
+
+        pSoa.GetViewZeroAlloc(view =>
+        {
+            Assert.True(view.IsEmpty);
+            Assert.Equal(0, view.FromTicks);
+            Assert.Equal(0, view.ToTicks);
+        });
+    }
+
+    [Fact]
+    public void GetView_Sets_FromTicks_ToTicks_For_AoS_And_SoA()
+    {
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        var pAos = new OptimizedPartition(8, StorageLayout.AoS);
+        var pSoa = new OptimizedPartition(8, StorageLayout.SoA);
+        for (int i = 0; i < 3; i++) { pAos.TryEnqueue(E(1, i + 1, t0 + i)); pSoa.TryEnqueue(E(1, i + 1, t0 + i)); }
+
+        var vAos = pAos.GetView();
+        Assert.Equal(t0, vAos.FromTicks);
+        Assert.Equal(t0 + 2, vAos.ToTicks);
+
+        var vSoa = pSoa.GetView();
+        Assert.Equal(t0, vSoa.FromTicks);
+        Assert.Equal(t0 + 2, vSoa.ToTicks);
+    }
+
+    [Fact]
+    public void GetViewZeroAlloc_Sets_Ticks_And_Works_When_Full()
+    {
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        var pAos = new OptimizedPartition(4, StorageLayout.AoS);
+        var pSoa = new OptimizedPartition(4, StorageLayout.SoA);
+        for (int i = 0; i < 6; i++) { pAos.TryEnqueue(E(1, i + 1, t0 + i)); pSoa.TryEnqueue(E(1, i + 1, t0 + i)); }
+
+        pAos.GetViewZeroAlloc(view =>
+        {
+            Assert.Equal(4, view.Count);
+            Assert.Equal(t0 + 2, view.FromTicks);
+            Assert.Equal(t0 + 5, view.ToTicks);
+        });
+
+        pSoa.GetViewZeroAlloc(view =>
+        {
+            Assert.Equal(4, view.Count);
+            Assert.Equal(t0 + 2, view.FromTicks);
+            Assert.Equal(t0 + 5, view.ToTicks);
+        });
+    }
+
+    [Fact]
+    public void IsFull_And_IsEmpty_Are_Accurate()
+    {
+        var p = new OptimizedPartition(3, StorageLayout.AoS);
+        Assert.True(p.IsEmpty);
+        Assert.False(p.IsFull);
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        for (int i = 0; i < 3; i++) p.TryEnqueue(E(1, i + 1, t0 + i));
+        Assert.False(p.IsEmpty);
+        Assert.True(p.IsFull);
+        p.Clear();
+        Assert.True(p.IsEmpty);
+        Assert.False(p.IsFull);
+    }
+
+    [Fact]
+    public void SoA_Discard_Callback_Is_Invoked_With_Overwritten_Event()
+    {
+        var discarded = new List<Event>();
+        var p = new OptimizedPartition(3, StorageLayout.SoA, discarded.Add);
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        for (int i = 0; i < 4; i++) p.TryEnqueue(E(1, i + 1, t0 + i));
+        Assert.NotEmpty(discarded);
+        // As in LockFreeRingBuffer, callback observes the value written into the overwritten slot
+        Assert.Contains(discarded, e => e.Value == 4d && e.TimestampTicks == t0 + 3);
+    }
+
+    [Fact]
+    public void SoA_TryEnqueueBatch_NoWrap_Then_Wrap_Maintains_Order()
+    {
+        var p = new OptimizedPartition(6, StorageLayout.SoA);
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        // No wrap
+        var first = Enumerable.Range(0, 3).Select(i => E(1, i + 1, t0 + i)).ToArray();
+        Assert.Equal(3, p.TryEnqueueBatch(first));
+        var v1 = p.GetView();
+        Assert.Equal(new[] { 1d, 2d, 3d }, Enumerate(v1).Select(e => e.Value).ToArray());
+        // Wrap after second batch
+        var second = Enumerable.Range(3, 5).Select(i => E(1, i + 1, t0 + i)).ToArray();
+        Assert.Equal(5, p.TryEnqueueBatch(second));
+        var v2 = p.GetView();
+        Assert.Equal(new[] { 3d, 4d, 5d, 6d, 7d, 8d }, Enumerate(v2).Select(e => e.Value).ToArray());
+    }
+
+    [Fact]
+    public void SoA_Direct_Spans_NoWrap_And_ZeroAlloc_NoWrap()
+    {
+        var p = new OptimizedPartition(6, StorageLayout.SoA);
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        for (int i = 0; i < 3; i++) p.TryEnqueue(E(i, i + 1, t0 + i));
+
+        // No wrap spans
+        var keys = p.GetKeysSpan();
+        var vals = p.GetValuesSpan();
+        var ts = p.GetTimestampsSpan();
+        var keysArr = keys.ToArray();
+        var valsArr = vals.ToArray();
+        var tsArr = ts.ToArray();
+        Assert.Equal(3, keys.Length);
+        Assert.Equal(3, vals.Length);
+        Assert.Equal(3, ts.Length);
+        Assert.Equal(new[] { new KeyId(0), new KeyId(1), new KeyId(2) }, keysArr);
+        Assert.Equal(new[] { 1d, 2d, 3d }, valsArr);
+        Assert.Equal(new[] { t0, t0 + 1, t0 + 2 }, tsArr);
+
+        // Zero-alloc getters with no wrap should call processor exactly once
+        int kc = 0, vc = 0, tc = 0;
+        p.GetKeysZeroAlloc(span => { kc++; Assert.Equal(keysArr, span.ToArray()); });
+        p.GetValuesZeroAlloc(span => { vc++; Assert.Equal(valsArr, span.ToArray()); });
+        p.GetTimestampsZeroAlloc(span => { tc++; Assert.Equal(tsArr, span.ToArray()); });
+        Assert.Equal(1, kc);
+        Assert.Equal(1, vc);
+        Assert.Equal(1, tc);
+    }
+
+    [Fact]
+    public void AoS_GetView_And_GetViewZeroAlloc_Handle_IsFull_HeadZero_SingleSegment()
+    {
+        var p = new OptimizedPartition(4, StorageLayout.AoS);
+        var t0 = new DateTime(2024, 1, 1).Ticks;
+        for (int i = 0; i < 4; i++) p.TryEnqueue(E(1, i + 1, t0 + i)); // exactly capacity; headIndex=0
+
+        var view = p.GetView();
+        Assert.False(view.HasWrapAround);
+        Assert.Equal(new[] { 1d, 2d, 3d, 4d }, Enumerate(view).Select(e => e.Value).ToArray());
+        Assert.Equal(t0, view.FromTicks);
+        Assert.Equal(t0 + 3, view.ToTicks);
+
+        p.GetViewZeroAlloc(v =>
+        {
+            Assert.False(v.HasWrapAround);
+            Assert.Equal(new[] { 1d, 2d, 3d, 4d }, Enumerate(v).Select(e => e.Value).ToArray());
+            Assert.Equal(t0, v.FromTicks);
+            Assert.Equal(t0 + 3, v.ToTicks);
+        });
+    }
 }

--- a/tests/LockFree.EventStore.Tests/PaddedLockFreeRingBufferCoverageTests.cs
+++ b/tests/LockFree.EventStore.Tests/PaddedLockFreeRingBufferCoverageTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using LockFree.EventStore;
+using Xunit;
+
+namespace LockFree.EventStore.Tests;
+
+public class PaddedLockFreeRingBufferCoverageTests
+{
+    [Fact]
+    public void TryEnqueueBatch_Overflow_Invokes_Discard_Callback_Advances_Head_And_Increments_Epoch()
+    {
+        var discarded = new List<int>();
+        var buf = new PaddedLockFreeRingBuffer<int>(5, discarded.Add);
+
+        // Fill exactly to capacity
+        buf.TryEnqueueBatch(new[] { 1, 2, 3, 4, 5 });
+        var before = buf.GetStatistics();
+        Assert.Equal(5, before.Count);
+        Assert.True(buf.IsFull);
+
+        // Enqueue a batch that overflows by 4
+        var written = buf.TryEnqueueBatch(new[] { 6, 7, 8, 9 });
+        Assert.Equal(4, written);
+
+        // Discard callback should be invoked once per overwritten slot with the NEW values
+        Assert.Equal(new[] { 6, 7, 8, 9 }, discarded);
+
+        // Head should advance by 4, count should remain at capacity, epoch must not decrease
+        var after = buf.GetStatistics();
+        Assert.Equal(before.Head + 4, after.Head);
+        Assert.Equal(5, after.Count);
+        Assert.True(after.Epoch >= before.Epoch);
+
+        // Snapshot reflects the newest 5 items
+        var arr = new int[5];
+        var n = buf.Snapshot(arr);
+        Assert.Equal(5, n);
+        Assert.Equal(new[] { 5, 6, 7, 8, 9 }, arr);
+    }
+
+    [Fact]
+    public void CreateView_With_TimestampSelector_Populates_From_To_Ticks()
+    {
+        var t0 = new DateTime(2024, 1, 1);
+        var sel = new EventTimestampSelector();
+        var buf = new PaddedLockFreeRingBuffer<Event>(4);
+
+        // No wrap: headIndex == 0, tailIndex == 0 with count == capacity
+        for (int i = 0; i < 4; i++)
+        {
+            buf.TryEnqueue(new Event(new KeyId(i), i + 1, t0.AddTicks(i).Ticks));
+        }
+
+        var view = buf.CreateView(sel);
+        Assert.False(view.IsEmpty);
+        Assert.Equal(4, view.Count);
+        Assert.Equal(t0.Ticks, view.FromTicks);
+        Assert.Equal(t0.AddTicks(3).Ticks, view.ToTicks);
+
+        var values = new List<double>();
+        foreach (var e in view) values.Add(e.Value);
+        Assert.Equal(new[] { 1d, 2d, 3d, 4d }, values);
+    }
+
+    [Fact]
+    public void CreateViewFiltered_With_Wrap_Returns_Two_Segments_And_Correct_Items()
+    {
+        var sel = new EventTimestampSelector();
+        var buf = new PaddedLockFreeRingBuffer<Event>(5);
+
+        // Enqueue 7 events so the buffer is full and headIndex != 0
+        for (int i = 1; i <= 7; i++)
+        {
+            buf.TryEnqueue(new Event(new KeyId(i), i, i)); // use ticks == i for simplicity
+        }
+
+        // Select timestamps 5..7 (inclusive). This spans across the physical end of the array.
+        var view = buf.CreateViewFiltered(5, 7, sel);
+        Assert.Equal(3, view.Count);
+        Assert.True(view.HasWrapAround);
+
+        var got = new List<double>();
+        foreach (var e in view) got.Add(e.Value);
+        Assert.Equal(new[] { 5d, 6d, 7d }, got);
+    }
+
+    [Fact]
+    public void Snapshot_With_Smaller_Destination_Copies_Partial()
+    {
+        var buf = new PaddedLockFreeRingBuffer<int>(6);
+        buf.TryEnqueueBatch(new[] { 1, 2, 3, 4, 5 });
+
+        var dst = new int[3];
+        var n = buf.Snapshot(dst);
+        Assert.Equal(3, n);
+        Assert.Equal(new[] { 1, 2, 3 }, dst);
+    }
+
+    [Fact]
+    public void ProcessItemsZeroAlloc_Processes_All_When_Not_Terminating()
+    {
+        var buf = new PaddedLockFreeRingBuffer<int>(8);
+        buf.TryEnqueueBatch(new[] { 1, 2, 3, 4, 5 });
+
+        buf.ProcessItemsZeroAlloc(0, (sum, item) => (sum + item, true), out var final);
+        Assert.Equal(1 + 2 + 3 + 4 + 5, final);
+    }
+}

--- a/tests/LockFree.EventStore.Tests/PaddedLockFreeRingBufferMoreTests.cs
+++ b/tests/LockFree.EventStore.Tests/PaddedLockFreeRingBufferMoreTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using System.Buffers;
+using LockFree.EventStore;
+using Xunit;
+
+namespace LockFree.EventStore.Tests;
+
+public class PaddedLockFreeRingBufferMoreTests
+{
+    [Fact]
+    public void Constructor_InvalidCapacity_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PaddedLockFreeRingBuffer<int>(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PaddedLockFreeRingBuffer<int>(-1));
+    }
+
+    [Fact]
+    public void IsEmpty_IsFull_And_Snapshot_Empty()
+    {
+        var buf = new PaddedLockFreeRingBuffer<int>(3);
+        Assert.True(buf.IsEmpty);
+        Assert.False(buf.IsFull);
+
+        var tmp = new int[3];
+        var n = buf.Snapshot(tmp);
+        Assert.Equal(0, n);
+
+        buf.TryEnqueue(1);
+        buf.TryEnqueue(2);
+        buf.TryEnqueue(3);
+        Assert.True(buf.IsFull);
+        Assert.False(buf.IsEmpty);
+    }
+
+    [Fact]
+    public void Clear_Resets_State_And_Increments_Epoch()
+    {
+        var buf = new PaddedLockFreeRingBuffer<int>(4);
+        buf.TryEnqueueBatch(new[] { 1, 2, 3 });
+        var before = buf.GetStatistics();
+        Assert.True(before.Count > 0);
+
+        buf.Clear();
+        var after = buf.GetStatistics();
+        Assert.Equal(0, after.Count);
+        Assert.Equal(after.Tail, after.Head);
+        Assert.True(after.Epoch >= before.Epoch);
+    }
+
+    [Fact]
+    public void GetStatistics_Reflects_Operations()
+    {
+        var buf = new PaddedLockFreeRingBuffer<int>(3);
+        var s0 = buf.GetStatistics();
+        Assert.Equal(0, s0.Head);
+        Assert.Equal(0, s0.Tail);
+        Assert.Equal(0, s0.Count);
+
+        buf.TryEnqueue(10);
+        var s1 = buf.GetStatistics();
+        Assert.Equal(1, s1.Tail);
+        Assert.True(s1.Count >= 1);
+
+        buf.TryEnqueueBatch(new[] { 20, 30, 40 }); // causes overwrite and epoch increment
+        var s2 = buf.GetStatistics();
+        Assert.True(s2.Tail >= s1.Tail);
+        Assert.True(s2.Count <= 3);
+        Assert.True(s2.Epoch >= s1.Epoch);
+    }
+
+    [Fact]
+    public void EnumerateSnapshot_Returns_All_Items()
+    {
+        var buf = new PaddedLockFreeRingBuffer<int>(5);
+        buf.TryEnqueueBatch(new[] { 1, 2, 3, 4 });
+        var list = buf.EnumerateSnapshot().ToArray();
+        Assert.Equal(new[] { 1, 2, 3, 4 }, list);
+    }
+
+    [Fact]
+    public void SnapshotZeroAlloc_With_ArrayPool_Works()
+    {
+        var buf = new PaddedLockFreeRingBuffer<int>(6);
+        buf.TryEnqueueBatch(new[] { 1, 2, 3, 4, 5 });
+
+        int total = 0;
+        buf.SnapshotZeroAlloc<int>(span => total += span.Length, ArrayPool<int>.Shared, chunkSize: 2);
+        Assert.Equal(5, total);
+    }
+}

--- a/tests/LockFree.EventStore.Tests/StoreStatsTests.cs
+++ b/tests/LockFree.EventStore.Tests/StoreStatsTests.cs
@@ -1,0 +1,24 @@
+using LockFree.EventStore;
+using Xunit;
+
+namespace LockFree.EventStore.Tests;
+
+public class StoreStatsTests
+{
+    [Fact]
+    public void Constructor_Sets_All_Properties()
+    {
+        var s = new StoreStats(appendCount: 10, droppedCount: 2, snapshotBytesExposed: 128, windowAdvanceCount: 7);
+        Assert.Equal(10, s.AppendCount);
+        Assert.Equal(2, s.DroppedCount);
+        Assert.Equal(128, s.SnapshotBytesExposed);
+        Assert.Equal(7, s.WindowAdvanceCount);
+    }
+
+    [Fact]
+    public void ToString_Formats_As_Expected()
+    {
+        var s = new StoreStats(3, 1, 64, 5);
+        Assert.Equal("StoreStats(Appends: 3, Dropped: 1, SnapshotBytes: 64, WindowAdvances: 5)", s.ToString());
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive unit test coverage for several core classes in the `LockFree.EventStore` library, focusing on ring buffers, partitions, statistics, and key mapping. The new tests validate correctness, edge cases, and internal behaviors, including buffer overflow, batch operations, view creation, statistics tracking, and zero-allocation APIs. These improvements help ensure reliability and maintainability of the event store implementation.

**Ring Buffer and Partition Coverage**

* Added extensive tests for `LockFreeRingBuffer`, `PaddedLockFreeRingBuffer`, and `OptimizedPartition`, including validation of construction, overflow/discard logic, wraparound, snapshotting, zero-alloc APIs, and view creation with timestamp selectors. These tests cover both normal and edge-case behaviors such as invalid capacities, clearing, and batch enqueues. [[1]](diffhunk://#diff-fd6e51993550bcc481ac6f0609eb9ee95c2d4bd3c9743e3a2894e0d628cc0721R140-R275) [[2]](diffhunk://#diff-ffecb69b68195abcf0dc9c317d802688641a50cbc6e35fc77094799c8d0ba9efR1-R111) [[3]](diffhunk://#diff-8cfa4e8d7a5bf43cde642fc8bb36a870fe448249e9bc5e4861057a9b0475393cR1-R91) [[4]](diffhunk://#diff-b1fba52331cc3828130b292122ff2efbd036efa607a78c996dcf5ee455a9118fR133-R320)

**Statistics and State Tracking**

* Introduced tests for `EventStoreStatistics` and `StoreStats`, verifying that counters, timestamps, and string formatting behave as expected under various operations including append, discard, overwrite, and reset. [[1]](diffhunk://#diff-9a7db1197212d4e7e32123566ee27183d0c91a29ce973c456b05c721ad663729R1-R76) [[2]](diffhunk://#diff-35a5cd096f15ebf9b14c61c48ab95bc9f2186c050761a942122e3a9eb442c156R1-R24)

**Key Mapping and Identifiers**

* Added tests for `KeyId` and `KeyMap`, ensuring correct equality, hashing, implicit conversions, mapping, clearing, and sequence behaviors.